### PR TITLE
Add 'import ai-economist'

### DIFF
--- a/tutorials/covid19_and_economic_simulation.ipynb
+++ b/tutorials/covid19_and_economic_simulation.ipynb
@@ -78,6 +78,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can install the ai-economist package using the pip package manager:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pip install ai-economist"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -830,7 +846,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.11"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The colab notebook does not import the ai-economist package by default, so we are adding it to make it work smoothly.