### PR TITLE
Raise / catch errors when WarpDrive is not installed on a GPU machine

### DIFF
--- a/ai_economist/foundation/components/covid19_components.py
+++ b/ai_economist/foundation/components/covid19_components.py
@@ -25,6 +25,12 @@ try:
 
         _OBSERVATIONS = Constants.OBSERVATIONS
         _ACTIONS = Constants.ACTIONS
+except ModuleNotFoundError:
+    print(
+        "Warning: The 'WarpDrive' package is not found! "
+        "If you wish to use WarpDrive, please run "
+        "'pip install rl-warp-drive' first."
+    )
 except ValueError:
     print("No GPUs found! Running the simulation on a CPU.")
 

--- a/ai_economist/foundation/components/covid19_components.py
+++ b/ai_economist/foundation/components/covid19_components.py
@@ -27,7 +27,7 @@ try:
         _ACTIONS = Constants.ACTIONS
 except ModuleNotFoundError:
     print(
-        "Warning: The 'WarpDrive' package is not found! "
+        "Warning: The 'WarpDrive' package is not found and cannot be used! "
         "If you wish to use WarpDrive, please run "
         "'pip install rl-warp-drive' first."
     )

--- a/ai_economist/foundation/env_cpu_gpu_consistency_checker.py
+++ b/ai_economist/foundation/env_cpu_gpu_consistency_checker.py
@@ -8,13 +8,10 @@
 Consistency tests for comparing the cuda (gpu) / no cuda (cpu) version
 """
 
+import sys
 from collections import defaultdict
 
 import GPUtil
-import numpy as np
-from gym.spaces import Discrete, MultiDiscrete
-
-from ai_economist.foundation.env_wrapper import FoundationEnvWrapper
 
 try:
     num_gpus_available = len(GPUtil.getAvailable())
@@ -25,10 +22,21 @@ try:
     import torch
     from warp_drive.utils.constants import Constants
     from warp_drive.utils.data_feed import DataFeed
+except ModuleNotFoundError:
+    print(
+        "This script requires the 'WarpDrive' package, please run "
+        "'pip install rl-warp-drive' first."
+    )
+    sys.exit()
 except ValueError:
     raise ValueError(
         "The env. consistency checker needs a GPU machine to run!!"
     ) from None
+
+import numpy as np
+from gym.spaces import Discrete, MultiDiscrete
+
+from ai_economist.foundation.env_wrapper import FoundationEnvWrapper
 
 pytorch_cuda_init_success = torch.cuda.FloatTensor(8)
 _OBSERVATIONS = Constants.OBSERVATIONS

--- a/ai_economist/foundation/env_cpu_gpu_consistency_checker.py
+++ b/ai_economist/foundation/env_cpu_gpu_consistency_checker.py
@@ -21,7 +21,7 @@ try:
     from warp_drive.utils.data_feed import DataFeed
 except ModuleNotFoundError:
     raise ModuleNotFoundError(
-        "The env. consistency checker requires the 'WarpDrive' package, please run "
+        "The env consistency checker requires the 'WarpDrive' package, please run "
         "'pip install rl-warp-drive' first."
     ) from None
 except ValueError:

--- a/ai_economist/foundation/env_cpu_gpu_consistency_checker.py
+++ b/ai_economist/foundation/env_cpu_gpu_consistency_checker.py
@@ -16,7 +16,7 @@ try:
     num_gpus_available = len(GPUtil.getAvailable())
     assert (
         num_gpus_available > 0
-    ), "The env. consistency checker needs a GPU machine to run!"
+    ), "The env consistency checker needs a GPU to run!"
     print(f"{num_gpus_available} GPUs are available.")
     import torch
     from warp_drive.utils.constants import Constants
@@ -28,7 +28,7 @@ except ModuleNotFoundError:
     ) from None
 except ValueError:
     raise ValueError(
-        "The env. consistency checker needs a GPU machine to run!"
+        "The env consistency checker needs a GPU to run!"
     ) from None
 
 import numpy as np

--- a/ai_economist/foundation/env_cpu_gpu_consistency_checker.py
+++ b/ai_economist/foundation/env_cpu_gpu_consistency_checker.py
@@ -8,7 +8,6 @@
 Consistency tests for comparing the cuda (gpu) / no cuda (cpu) version
 """
 
-import sys
 from collections import defaultdict
 
 import GPUtil
@@ -17,20 +16,19 @@ try:
     num_gpus_available = len(GPUtil.getAvailable())
     assert (
         num_gpus_available > 0
-    ), "The env. consistency checker needs a GPU machine to run!!"
+    ), "The env. consistency checker needs a GPU machine to run!"
     print(f"{num_gpus_available} GPUs are available.")
     import torch
     from warp_drive.utils.constants import Constants
     from warp_drive.utils.data_feed import DataFeed
 except ModuleNotFoundError:
-    print(
-        "This script requires the 'WarpDrive' package, please run "
+    raise ModuleNotFoundError(
+        "The env. consistency checker requires the 'WarpDrive' package, please run "
         "'pip install rl-warp-drive' first."
-    )
-    sys.exit()
+    ) from None
 except ValueError:
     raise ValueError(
-        "The env. consistency checker needs a GPU machine to run!!"
+        "The env. consistency checker needs a GPU machine to run!"
     ) from None
 
 import numpy as np

--- a/ai_economist/foundation/env_cpu_gpu_consistency_checker.py
+++ b/ai_economist/foundation/env_cpu_gpu_consistency_checker.py
@@ -14,9 +14,7 @@ import GPUtil
 
 try:
     num_gpus_available = len(GPUtil.getAvailable())
-    assert (
-        num_gpus_available > 0
-    ), "The env consistency checker needs a GPU to run!"
+    assert num_gpus_available > 0, "The env consistency checker needs a GPU to run!"
     print(f"{num_gpus_available} GPUs are available.")
     import torch
     from warp_drive.utils.constants import Constants
@@ -27,9 +25,7 @@ except ModuleNotFoundError:
         "'pip install rl-warp-drive' first."
     ) from None
 except ValueError:
-    raise ValueError(
-        "The env consistency checker needs a GPU to run!"
-    ) from None
+    raise ValueError("The env consistency checker needs a GPU to run!") from None
 
 import numpy as np
 from gym.spaces import Discrete, MultiDiscrete

--- a/ai_economist/foundation/env_wrapper.py
+++ b/ai_economist/foundation/env_wrapper.py
@@ -8,26 +8,23 @@
 The env wrapper class
 """
 
-import sys
-
 import GPUtil
 
 try:
     num_gpus_available = len(GPUtil.getAvailable())
-    assert num_gpus_available > 0, "This script needs a GPU machine to run!!"
+    assert num_gpus_available > 0, "This script needs a GPU machine to run!"
     print(f"{num_gpus_available} GPUs are available.")
     from warp_drive.env_wrapper import EnvWrapper
     from warp_drive.utils.recursive_obs_dict_to_spaces_dict import (
         recursive_obs_dict_to_spaces_dict,
     )
 except ModuleNotFoundError:
-    print(
-        "This script requires the 'WarpDrive' package, please run "
+    raise ModuleNotFoundError(
+        "The env. wrapper requires the 'WarpDrive' package, please run "
         "'pip install rl-warp-drive' first."
-    )
-    sys.exit()
+    ) from None
 except ValueError:
-    print("No GPUs found! Running the simulation on a CPU.")
+    raise ValueError("The env. wrapper needs a GPU machine to run!") from None
 
 import numpy as np
 from gym.spaces import Discrete, MultiDiscrete

--- a/ai_economist/foundation/env_wrapper.py
+++ b/ai_economist/foundation/env_wrapper.py
@@ -8,23 +8,29 @@
 The env wrapper class
 """
 
+import sys
+
 import GPUtil
-import numpy as np
-from gym.spaces import Discrete, MultiDiscrete
 
 try:
     num_gpus_available = len(GPUtil.getAvailable())
     assert num_gpus_available > 0, "This script needs a GPU machine to run!!"
-    if num_gpus_available == 0:
-        print("No GPUs found! Running the simulation on a CPU.")
-    else:
-        print(f"{num_gpus_available} GPUs are available.")
-        from warp_drive.env_wrapper import EnvWrapper
-        from warp_drive.utils.recursive_obs_dict_to_spaces_dict import (
-            recursive_obs_dict_to_spaces_dict,
-        )
+    print(f"{num_gpus_available} GPUs are available.")
+    from warp_drive.env_wrapper import EnvWrapper
+    from warp_drive.utils.recursive_obs_dict_to_spaces_dict import (
+        recursive_obs_dict_to_spaces_dict,
+    )
+except ModuleNotFoundError:
+    print(
+        "This script requires the 'WarpDrive' package, please run "
+        "'pip install rl-warp-drive' first."
+    )
+    sys.exit()
 except ValueError:
     print("No GPUs found! Running the simulation on a CPU.")
+
+import numpy as np
+from gym.spaces import Discrete, MultiDiscrete
 
 
 class FoundationEnvWrapper(EnvWrapper):

--- a/ai_economist/foundation/env_wrapper.py
+++ b/ai_economist/foundation/env_wrapper.py
@@ -12,7 +12,7 @@ import GPUtil
 
 try:
     num_gpus_available = len(GPUtil.getAvailable())
-    assert num_gpus_available > 0, "This script needs a GPU machine to run!"
+    assert num_gpus_available > 0, "This script needs a GPU to run!"
     print(f"{num_gpus_available} GPUs are available.")
     from warp_drive.env_wrapper import EnvWrapper
     from warp_drive.utils.recursive_obs_dict_to_spaces_dict import (
@@ -20,11 +20,11 @@ try:
     )
 except ModuleNotFoundError:
     raise ModuleNotFoundError(
-        "The env. wrapper requires the 'WarpDrive' package, please run "
+        "The env wrapper requires the 'WarpDrive' package, please run "
         "'pip install rl-warp-drive' first."
     ) from None
 except ValueError:
-    raise ValueError("The env. wrapper needs a GPU machine to run!") from None
+    raise ValueError("The env wrapper needs a GPU to run!") from None
 
 import numpy as np
 from gym.spaces import Discrete, MultiDiscrete

--- a/ai_economist/foundation/scenarios/covid19/covid19_env.py
+++ b/ai_economist/foundation/scenarios/covid19/covid19_env.py
@@ -26,6 +26,12 @@ try:
         _OBSERVATIONS = Constants.OBSERVATIONS
         _ACTIONS = Constants.ACTIONS
         _REWARDS = Constants.REWARDS
+except ModuleNotFoundError:
+    print(
+        "Warning: The 'WarpDrive' package is not found! "
+        "If you wish to use WarpDrive, please run "
+        "'pip install rl-warp-drive' first."
+    )
 except ValueError:
     print("No GPUs found! Running the simulation on a CPU.")
 

--- a/ai_economist/foundation/scenarios/covid19/covid19_env.py
+++ b/ai_economist/foundation/scenarios/covid19/covid19_env.py
@@ -28,7 +28,7 @@ try:
         _REWARDS = Constants.REWARDS
 except ModuleNotFoundError:
     print(
-        "Warning: The 'WarpDrive' package is not found! "
+        "Warning: The 'WarpDrive' package is not found and cannot be used! "
         "If you wish to use WarpDrive, please run "
         "'pip install rl-warp-drive' first."
     )

--- a/ai_economist/training/training_script.py
+++ b/ai_economist/training/training_script.py
@@ -13,13 +13,9 @@ using `pip install rl-warp-drive`, and Pytorch(https://pytorch.org/)
 
 import argparse
 import os
+import sys
 
 import GPUtil
-
-from ai_economist.foundation.env_wrapper import FoundationEnvWrapper
-from ai_economist.foundation.scenarios.covid19.covid19_env import (
-    CovidAndEconomyEnvironment,
-)
 
 try:
     num_gpus_available = len(GPUtil.getAvailable())
@@ -30,8 +26,19 @@ try:
     from warp_drive.training.trainer import Trainer
     from warp_drive.training.utils.data_loader import create_and_push_data_placeholders
     from warp_drive.utils.env_registrar import CustomizedEnvironmentRegistrar
+except ModuleNotFoundError:
+    print(
+        "This script requires the 'WarpDrive' package, please run "
+        "'pip install rl-warp-drive' first."
+    )
+    sys.exit()
 except ValueError:
     raise ValueError("This training script needs a GPU machine to run!!") from None
+
+from ai_economist.foundation.env_wrapper import FoundationEnvWrapper
+from ai_economist.foundation.scenarios.covid19.covid19_env import (
+    CovidAndEconomyEnvironment,
+)
 
 pytorch_cuda_init_success = torch.cuda.FloatTensor(8)
 _COVID_AND_ECONOMY_ENVIRONMENT = "covid_and_economy_environment"

--- a/ai_economist/training/training_script.py
+++ b/ai_economist/training/training_script.py
@@ -13,13 +13,12 @@ using `pip install rl-warp-drive`, and Pytorch(https://pytorch.org/)
 
 import argparse
 import os
-import sys
 
 import GPUtil
 
 try:
     num_gpus_available = len(GPUtil.getAvailable())
-    assert num_gpus_available > 0, "This training script needs a GPU machine to run!!"
+    assert num_gpus_available > 0, "This training script needs a GPU machine to run!"
     print(f"{num_gpus_available} GPUs are available.")
     import torch
     import yaml
@@ -27,13 +26,12 @@ try:
     from warp_drive.training.utils.data_loader import create_and_push_data_placeholders
     from warp_drive.utils.env_registrar import CustomizedEnvironmentRegistrar
 except ModuleNotFoundError:
-    print(
-        "This script requires the 'WarpDrive' package, please run "
+    raise ModuleNotFoundError(
+        "This training script requires the 'WarpDrive' package, please run "
         "'pip install rl-warp-drive' first."
-    )
-    sys.exit()
+    ) from None
 except ValueError:
-    raise ValueError("This training script needs a GPU machine to run!!") from None
+    raise ValueError("This training script needs a GPU machine to run!") from None
 
 from ai_economist.foundation.env_wrapper import FoundationEnvWrapper
 from ai_economist.foundation.scenarios.covid19.covid19_env import (

--- a/ai_economist/training/training_script.py
+++ b/ai_economist/training/training_script.py
@@ -18,7 +18,7 @@ import GPUtil
 
 try:
     num_gpus_available = len(GPUtil.getAvailable())
-    assert num_gpus_available > 0, "This training script needs a GPU machine to run!"
+    assert num_gpus_available > 0, "This training script needs a GPU to run!"
     print(f"{num_gpus_available} GPUs are available.")
     import torch
     import yaml
@@ -31,7 +31,7 @@ except ModuleNotFoundError:
         "'pip install rl-warp-drive' first."
     ) from None
 except ValueError:
-    raise ValueError("This training script needs a GPU machine to run!") from None
+    raise ValueError("This training script needs a GPU to run!") from None
 
 from ai_economist.foundation.env_wrapper import FoundationEnvWrapper
 from ai_economist.foundation.scenarios.covid19.covid19_env import (


### PR DESCRIPTION
catch exceptions for running ai_economist on a GPU machine, but without WarpDrive