### PR TITLE
Make the colab notebooks python env to py37

### DIFF
--- a/tutorials/covid19_and_economic_simulation.ipynb
+++ b/tutorials/covid19_and_economic_simulation.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -11,6 +12,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -20,6 +22,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -31,6 +34,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -38,6 +42,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -51,6 +56,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -58,6 +64,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -71,6 +78,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -78,10 +86,61 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "You can install the ai-economist package using the pip package manager:"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Switch the python version to 3.7 if the env is based on Colab."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, signal, sys, time\n",
+    "IN_COLAB = 'google.colab' in sys.modules\n",
+    "\n",
+    "if IN_COLAB:\n",
+    "    # Reference: https://stackoverflow.com/a/74538231\n",
+    "    #install python 3.7\n",
+    "    !sudo apt-get update -y\n",
+    "    !sudo apt-get install python3.7\n",
+    "\n",
+    "    #change alternatives\n",
+    "    !sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1\n",
+    "    !sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2\n",
+    "\n",
+    "    # install pip for new python \n",
+    "    !sudo apt-get install python3.7-distutils\n",
+    "    !wget https://bootstrap.pypa.io/get-pip.py\n",
+    "    !python get-pip.py\n",
+    "\n",
+    "    # credit of these last two commands blongs to @Erik\n",
+    "    # install colab's dependencies\n",
+    "    !python -m pip install ipython ipython_genutils ipykernel jupyter_console prompt_toolkit httplib2 astor\n",
+    "\n",
+    "    # link to the old google package\n",
+    "    !ln -s /usr/local/lib/python3.10/dist-packages/google \\\n",
+    "        /usr/local/lib/python3.7/dist-packages/google\n",
+    "\n",
+    "    # There has got to be a better way to do this...but there's a bad import in some of the colab files\n",
+    "    # IPython no longer exposes traitlets like this, it's a separate package now\n",
+    "    !sed -i \"s/from IPython.utils import traitlets as _traitlets/import traitlets as _traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
+    "    !sed -i \"s/from IPython.utils import traitlets/import traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
+    "    print(\"\\n\\nRestarting the Python runtime! Please (re-)run the cells below.\")\n",
+    "    # Restart Runtime!!!\n",
+    "    import os\n",
+    "    os.kill(os.getpid(), 9)"
    ]
   },
   {
@@ -121,6 +180,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -135,6 +195,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -242,6 +303,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -260,6 +322,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -277,6 +340,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -284,6 +348,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -388,6 +453,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -417,6 +483,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -445,6 +512,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -585,6 +653,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -597,6 +666,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -619,6 +689,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -641,6 +712,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -675,6 +747,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -694,6 +767,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -701,6 +775,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -712,6 +787,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -766,6 +842,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -773,6 +850,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -825,6 +903,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -834,6 +913,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/tutorials/economic_simulation_advanced.ipynb
+++ b/tutorials/economic_simulation_advanced.ipynb
@@ -140,7 +140,7 @@
     "    # IPython no longer exposes traitlets like this, it's a separate package now\n",
     "    !sed -i \"s/from IPython.utils import traitlets as _traitlets/import traitlets as _traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
     "    !sed -i \"s/from IPython.utils import traitlets/import traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
-    "\n",
+    "    print(\"\\n\\nRestarting the Python runtime! Please (re-)run the cells below.\")\n",
     "    # Restart Runtime!!!\n",
     "    import os\n",
     "    os.kill(os.getpid(), 9)"

--- a/tutorials/economic_simulation_advanced.ipynb
+++ b/tutorials/economic_simulation_advanced.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -11,6 +12,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -20,6 +22,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -54,6 +57,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -83,12 +87,63 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Dependencies\n",
     "\n",
     "You can install the ai-economist package using the pip package manager:"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Switch the python version to 3.7 if the env is based on Colab."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, signal, sys, time\n",
+    "IN_COLAB = 'google.colab' in sys.modules\n",
+    "\n",
+    "if IN_COLAB:\n",
+    "    # Reference: https://stackoverflow.com/a/74538231\n",
+    "    #install python 3.7\n",
+    "    !sudo apt-get update -y\n",
+    "    !sudo apt-get install python3.7\n",
+    "\n",
+    "    #change alternatives\n",
+    "    !sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1\n",
+    "    !sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2\n",
+    "\n",
+    "    # install pip for new python \n",
+    "    !sudo apt-get install python3.7-distutils\n",
+    "    !wget https://bootstrap.pypa.io/get-pip.py\n",
+    "    !python get-pip.py\n",
+    "\n",
+    "    # credit of these last two commands blongs to @Erik\n",
+    "    # install colab's dependencies\n",
+    "    !python -m pip install ipython ipython_genutils ipykernel jupyter_console prompt_toolkit httplib2 astor\n",
+    "\n",
+    "    # link to the old google package\n",
+    "    !ln -s /usr/local/lib/python3.10/dist-packages/google \\\n",
+    "        /usr/local/lib/python3.7/dist-packages/google\n",
+    "\n",
+    "    # There has got to be a better way to do this...but there's a bad import in some of the colab files\n",
+    "    # IPython no longer exposes traitlets like this, it's a separate package now\n",
+    "    !sed -i \"s/from IPython.utils import traitlets as _traitlets/import traitlets as _traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
+    "    !sed -i \"s/from IPython.utils import traitlets/import traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
+    "\n",
+    "    # Restart Runtime!!!\n",
+    "    import os\n",
+    "    os.kill(os.getpid(), 9)"
    ]
   },
   {
@@ -121,6 +176,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -159,6 +215,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -205,6 +262,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -254,6 +312,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -321,6 +380,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -350,6 +410,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -367,6 +428,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -383,6 +445,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -422,6 +485,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -438,6 +502,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -463,6 +528,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -480,6 +546,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -498,6 +565,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -514,6 +582,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -529,6 +598,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -551,6 +621,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -574,6 +645,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -583,6 +655,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -603,6 +676,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -626,6 +700,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -644,6 +719,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -655,6 +731,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -677,6 +754,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -695,6 +773,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -715,6 +794,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -731,6 +811,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -749,6 +830,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -783,6 +865,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -800,6 +883,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -818,6 +902,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -844,6 +929,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -860,6 +946,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -877,6 +964,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -915,6 +1003,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -929,6 +1018,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -943,6 +1033,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -959,6 +1050,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -975,6 +1067,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -991,6 +1084,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1033,6 +1127,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1042,6 +1137,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1055,6 +1151,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1104,6 +1201,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1143,6 +1241,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1152,6 +1251,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1176,6 +1276,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1183,6 +1284,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1215,6 +1317,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1236,6 +1339,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1254,6 +1358,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1283,6 +1388,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1324,6 +1430,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1348,6 +1455,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1435,6 +1543,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1476,6 +1585,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1501,6 +1611,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1540,6 +1651,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1574,6 +1686,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1583,6 +1696,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1603,6 +1717,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1637,6 +1752,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1655,6 +1771,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1666,6 +1783,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1673,6 +1791,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1682,6 +1801,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1693,6 +1813,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1709,6 +1830,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1737,6 +1859,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1752,6 +1875,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/tutorials/economic_simulation_basic.ipynb
+++ b/tutorials/economic_simulation_basic.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -11,6 +12,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -20,6 +22,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -37,6 +40,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -52,6 +56,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -59,6 +64,56 @@
     "You can install the ai-economist package using \n",
     "- the pip package manager OR\n",
     "- by cloning the ai-economist package and installing the requirements (we shall use this when running on Colab):"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Switch the python version to 3.7 if the env is based on Colab."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, signal, sys, time\n",
+    "IN_COLAB = 'google.colab' in sys.modules\n",
+    "\n",
+    "if IN_COLAB:\n",
+    "    # Reference: https://stackoverflow.com/a/74538231\n",
+    "    #install python 3.7\n",
+    "    !sudo apt-get update -y\n",
+    "    !sudo apt-get install python3.7\n",
+    "\n",
+    "    #change alternatives\n",
+    "    !sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1\n",
+    "    !sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2\n",
+    "\n",
+    "    # install pip for new python \n",
+    "    !sudo apt-get install python3.7-distutils\n",
+    "    !wget https://bootstrap.pypa.io/get-pip.py\n",
+    "    !python get-pip.py\n",
+    "\n",
+    "    # credit of these last two commands blongs to @Erik\n",
+    "    # install colab's dependencies\n",
+    "    !python -m pip install ipython ipython_genutils ipykernel jupyter_console prompt_toolkit httplib2 astor\n",
+    "\n",
+    "    # link to the old google package\n",
+    "    !ln -s /usr/local/lib/python3.10/dist-packages/google \\\n",
+    "        /usr/local/lib/python3.7/dist-packages/google\n",
+    "\n",
+    "    # There has got to be a better way to do this...but there's a bad import in some of the colab files\n",
+    "    # IPython no longer exposes traitlets like this, it's a separate package now\n",
+    "    !sed -i \"s/from IPython.utils import traitlets as _traitlets/import traitlets as _traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
+    "    !sed -i \"s/from IPython.utils import traitlets/import traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
+    "\n",
+    "    # Restart Runtime!!!\n",
+    "    import os\n",
+    "    os.kill(os.getpid(), 9)"
    ]
   },
   {
@@ -125,6 +180,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -144,6 +200,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -218,6 +275,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -234,6 +292,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -241,6 +300,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -261,6 +321,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -307,6 +368,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -325,6 +387,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -342,6 +405,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -349,6 +413,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -367,6 +432,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -391,6 +457,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -410,6 +477,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -430,6 +498,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -448,6 +517,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -504,6 +574,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -513,6 +584,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -567,6 +639,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/tutorials/economic_simulation_basic.ipynb
+++ b/tutorials/economic_simulation_basic.ipynb
@@ -110,7 +110,7 @@
     "    # IPython no longer exposes traitlets like this, it's a separate package now\n",
     "    !sed -i \"s/from IPython.utils import traitlets as _traitlets/import traitlets as _traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
     "    !sed -i \"s/from IPython.utils import traitlets/import traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
-    "\n",
+    "    print(\"\\n\\nRestarting the Python runtime! Please (re-)run the cells below.\")\n",
     "    # Restart Runtime!!!\n",
     "    import os\n",
     "    os.kill(os.getpid(), 9)"

--- a/tutorials/multi_agent_gpu_training_with_warp_drive.ipynb
+++ b/tutorials/multi_agent_gpu_training_with_warp_drive.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a1349103",
    "metadata": {},
@@ -12,6 +13,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9f928d76",
    "metadata": {},
@@ -22,6 +24,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9d85d358",
    "metadata": {},
@@ -32,6 +35,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "073387a4",
    "metadata": {},
@@ -53,6 +57,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "2e761c0d",
    "metadata": {},
@@ -68,6 +73,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8b87df34",
    "metadata": {},
@@ -76,11 +82,64 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "55bb9c3b",
    "metadata": {},
    "source": [
     "You will need to install the [AI Economist](https://github.com/salesforce/ai-economist) and [WarpDrive](https://github.com/salesforce/warp-drive) pip packages."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "9b758212",
+   "metadata": {},
+   "source": [
+    "Switch the python version to 3.7 if the env is based on Colab."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32e1eb56",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, signal, sys, time\n",
+    "IN_COLAB = 'google.colab' in sys.modules\n",
+    "\n",
+    "if IN_COLAB:\n",
+    "    # Reference: https://stackoverflow.com/a/74538231\n",
+    "    #install python 3.7\n",
+    "    !sudo apt-get update -y\n",
+    "    !sudo apt-get install python3.7\n",
+    "\n",
+    "    #change alternatives\n",
+    "    !sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1\n",
+    "    !sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2\n",
+    "\n",
+    "    # install pip for new python \n",
+    "    !sudo apt-get install python3.7-distutils\n",
+    "    !wget https://bootstrap.pypa.io/get-pip.py\n",
+    "    !python get-pip.py\n",
+    "\n",
+    "    # credit of these last two commands blongs to @Erik\n",
+    "    # install colab's dependencies\n",
+    "    !python -m pip install ipython ipython_genutils ipykernel jupyter_console prompt_toolkit httplib2 astor\n",
+    "\n",
+    "    # link to the old google package\n",
+    "    !ln -s /usr/local/lib/python3.10/dist-packages/google \\\n",
+    "        /usr/local/lib/python3.7/dist-packages/google\n",
+    "\n",
+    "    # There has got to be a better way to do this...but there's a bad import in some of the colab files\n",
+    "    # IPython no longer exposes traitlets like this, it's a separate package now\n",
+    "    !sed -i \"s/from IPython.utils import traitlets as _traitlets/import traitlets as _traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
+    "    !sed -i \"s/from IPython.utils import traitlets/import traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
+    "\n",
+    "    # Restart Runtime!!!\n",
+    "    import os\n",
+    "    os.kill(os.getpid(), 9)"
    ]
   },
   {
@@ -178,6 +237,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ac34e846",
    "metadata": {},
@@ -186,6 +246,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b9cbb4a4",
    "metadata": {},
@@ -245,6 +306,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e4645b43",
    "metadata": {},
@@ -253,6 +315,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "01f9b8ae",
    "metadata": {},
@@ -261,6 +324,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a990b032",
    "metadata": {},
@@ -307,6 +371,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "364047c4",
    "metadata": {},
@@ -332,6 +397,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "213dbdf0",
    "metadata": {},
@@ -384,6 +450,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b8f128d8",
    "metadata": {},
@@ -412,6 +479,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "f867963d",
    "metadata": {},
@@ -420,6 +488,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "c83bf539",
    "metadata": {},
@@ -428,6 +497,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e5d7f438",
    "metadata": {},
@@ -444,6 +514,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ede05b74",
    "metadata": {},
@@ -464,6 +535,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "aa259b4e",
    "metadata": {},
@@ -486,6 +558,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "a204d966",
    "metadata": {},
@@ -494,6 +567,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1fbea778",
    "metadata": {},
@@ -520,6 +594,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ed835bbd",
    "metadata": {},
@@ -528,6 +603,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "4c758763",
    "metadata": {},
@@ -552,6 +628,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "8bb37f72",
    "metadata": {},
@@ -560,6 +637,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9a582b81",
    "metadata": {},
@@ -626,6 +704,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "d626a15a",
    "metadata": {},
@@ -634,6 +713,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "28a6846a",
    "metadata": {},
@@ -642,6 +722,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "4f0aac10",
    "metadata": {},
@@ -661,6 +742,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "9f71acf9",
    "metadata": {},
@@ -669,6 +751,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ac0973cb",
    "metadata": {},
@@ -782,6 +865,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1649b9c5",
    "metadata": {},

--- a/tutorials/multi_agent_gpu_training_with_warp_drive.ipynb
+++ b/tutorials/multi_agent_gpu_training_with_warp_drive.ipynb
@@ -136,7 +136,7 @@
     "    # IPython no longer exposes traitlets like this, it's a separate package now\n",
     "    !sed -i \"s/from IPython.utils import traitlets as _traitlets/import traitlets as _traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
     "    !sed -i \"s/from IPython.utils import traitlets/import traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
-    "\n",
+    "    print(\"\\n\\nRestarting the Python runtime! Please (re-)run the cells below.\")\n",
     "    # Restart Runtime!!!\n",
     "    import os\n",
     "    os.kill(os.getpid(), 9)"

--- a/tutorials/multi_agent_training_with_rllib.ipynb
+++ b/tutorials/multi_agent_training_with_rllib.ipynb
@@ -115,7 +115,7 @@
     "    # IPython no longer exposes traitlets like this, it's a separate package now\n",
     "    !sed -i \"s/from IPython.utils import traitlets as _traitlets/import traitlets as _traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
     "    !sed -i \"s/from IPython.utils import traitlets/import traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
-    "\n",
+    "    print(\"\\n\\nRestarting the Python runtime! Please (re-)run the cells below.\")\n",
     "    # Restart Runtime!!!\n",
     "    import os\n",
     "    os.kill(os.getpid(), 9)"

--- a/tutorials/multi_agent_training_with_rllib.ipynb
+++ b/tutorials/multi_agent_training_with_rllib.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -11,6 +12,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -20,6 +22,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -32,6 +35,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -39,6 +43,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -56,6 +61,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -63,6 +69,56 @@
     "You can install the ai-economist package using \n",
     "- the pip package manager OR\n",
     "- by cloning the ai-economist package and installing the requirements (we shall use this when running on Colab):"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Switch the python version to 3.7 if the env is based on Colab."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, signal, sys, time\n",
+    "IN_COLAB = 'google.colab' in sys.modules\n",
+    "\n",
+    "if IN_COLAB:\n",
+    "    # Reference: https://stackoverflow.com/a/74538231\n",
+    "    #install python 3.7\n",
+    "    !sudo apt-get update -y\n",
+    "    !sudo apt-get install python3.7\n",
+    "\n",
+    "    #change alternatives\n",
+    "    !sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1\n",
+    "    !sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2\n",
+    "\n",
+    "    # install pip for new python \n",
+    "    !sudo apt-get install python3.7-distutils\n",
+    "    !wget https://bootstrap.pypa.io/get-pip.py\n",
+    "    !python get-pip.py\n",
+    "\n",
+    "    # credit of these last two commands blongs to @Erik\n",
+    "    # install colab's dependencies\n",
+    "    !python -m pip install ipython ipython_genutils ipykernel jupyter_console prompt_toolkit httplib2 astor\n",
+    "\n",
+    "    # link to the old google package\n",
+    "    !ln -s /usr/local/lib/python3.10/dist-packages/google \\\n",
+    "        /usr/local/lib/python3.7/dist-packages/google\n",
+    "\n",
+    "    # There has got to be a better way to do this...but there's a bad import in some of the colab files\n",
+    "    # IPython no longer exposes traitlets like this, it's a separate package now\n",
+    "    !sed -i \"s/from IPython.utils import traitlets as _traitlets/import traitlets as _traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
+    "    !sed -i \"s/from IPython.utils import traitlets/import traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
+    "\n",
+    "    # Restart Runtime!!!\n",
+    "    import os\n",
+    "    os.kill(os.getpid(), 9)"
    ]
   },
   {
@@ -89,6 +145,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -105,6 +162,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -144,6 +202,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -151,6 +210,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -236,6 +296,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -255,6 +316,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -274,6 +336,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -281,6 +344,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -300,6 +364,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -356,6 +421,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -378,6 +444,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -413,6 +480,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -439,6 +507,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -471,6 +540,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -478,6 +548,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -500,6 +571,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -510,6 +582,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -517,6 +590,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -530,6 +604,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -537,6 +612,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -570,6 +646,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -577,6 +654,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -644,6 +722,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -651,6 +730,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -680,6 +760,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/tutorials/optimal_taxation_theory_and_simulation.ipynb
+++ b/tutorials/optimal_taxation_theory_and_simulation.ipynb
@@ -246,7 +246,7 @@
     "    # IPython no longer exposes traitlets like this, it's a separate package now\n",
     "    !sed -i \"s/from IPython.utils import traitlets as _traitlets/import traitlets as _traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
     "    !sed -i \"s/from IPython.utils import traitlets/import traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
-    "\n",
+    "    print(\"\\n\\nRestarting the Python runtime! Please (re-)run the cells below.\")\n",
     "    # Restart Runtime!!!\n",
     "    import os\n",
     "    os.kill(os.getpid(), 9)"

--- a/tutorials/optimal_taxation_theory_and_simulation.ipynb
+++ b/tutorials/optimal_taxation_theory_and_simulation.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -11,6 +12,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -20,6 +22,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -31,6 +34,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -38,6 +42,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -53,6 +58,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -65,6 +71,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -125,6 +132,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -135,6 +143,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -150,6 +159,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -166,6 +176,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -181,6 +192,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -188,6 +200,56 @@
     "You can install the ai-economist package using \n",
     "- the pip package manager OR\n",
     "- by cloning the ai-economist package and installing the requirements (we shall use this when running on Colab):"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Switch the python version to 3.7 if the env is based on Colab."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, signal, sys, time\n",
+    "IN_COLAB = 'google.colab' in sys.modules\n",
+    "\n",
+    "if IN_COLAB:\n",
+    "    # Reference: https://stackoverflow.com/a/74538231\n",
+    "    #install python 3.7\n",
+    "    !sudo apt-get update -y\n",
+    "    !sudo apt-get install python3.7\n",
+    "\n",
+    "    #change alternatives\n",
+    "    !sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1\n",
+    "    !sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2\n",
+    "\n",
+    "    # install pip for new python \n",
+    "    !sudo apt-get install python3.7-distutils\n",
+    "    !wget https://bootstrap.pypa.io/get-pip.py\n",
+    "    !python get-pip.py\n",
+    "\n",
+    "    # credit of these last two commands blongs to @Erik\n",
+    "    # install colab's dependencies\n",
+    "    !python -m pip install ipython ipython_genutils ipykernel jupyter_console prompt_toolkit httplib2 astor\n",
+    "\n",
+    "    # link to the old google package\n",
+    "    !ln -s /usr/local/lib/python3.10/dist-packages/google \\\n",
+    "        /usr/local/lib/python3.7/dist-packages/google\n",
+    "\n",
+    "    # There has got to be a better way to do this...but there's a bad import in some of the colab files\n",
+    "    # IPython no longer exposes traitlets like this, it's a separate package now\n",
+    "    !sed -i \"s/from IPython.utils import traitlets as _traitlets/import traitlets as _traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
+    "    !sed -i \"s/from IPython.utils import traitlets/import traitlets/\" /usr/local/lib/python3.7/dist-packages/google/colab/*.py\n",
+    "\n",
+    "    # Restart Runtime!!!\n",
+    "    import os\n",
+    "    os.kill(os.getpid(), 9)"
    ]
   },
   {
@@ -279,6 +341,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -296,6 +359,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -303,6 +367,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -321,6 +386,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -337,6 +403,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -364,6 +431,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -375,6 +443,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -420,6 +489,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -431,6 +501,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -494,6 +565,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -505,6 +577,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -610,6 +683,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -621,6 +695,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -636,6 +711,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -701,6 +777,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -712,6 +789,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -762,6 +840,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -774,6 +853,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -822,6 +902,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -839,6 +920,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -857,6 +939,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -874,6 +957,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -894,6 +978,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -923,6 +1008,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -932,6 +1018,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -960,6 +1047,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -977,6 +1065,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1056,6 +1145,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1067,6 +1157,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1080,6 +1171,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1094,6 +1186,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
The colab env is now py310 and ai-economist is not compatible for it. I switch the colab notebooks python env to py37.